### PR TITLE
Add uncertainty in the this_mu plotting for QSOLoaderZ

### DIFF
--- a/CDDF_analysis/qso_loader.py
+++ b/CDDF_analysis/qso_loader.py
@@ -1387,6 +1387,8 @@ class QSOLoaderZ(QSOLoader):
         this_sample_log_posteriors_no_dla = self.sample_log_posteriors_no_dla[:, nspec_nan]
         this_sample_log_posteriors_dla    = self.sample_log_posteriors_dla[:, nspec_nan]
 
+        assert self.processed_file['z_true'][0, nspec_nan] == self.z_true[nspec]
+
         this_sample_log_posteriors = logsumexp([
             this_sample_log_posteriors_no_dla, this_sample_log_posteriors_dla], axis=0)
 

--- a/CDDF_analysis/qso_loader.py
+++ b/CDDF_analysis/qso_loader.py
@@ -21,6 +21,7 @@ import h5py
 import numpy as np 
 from scipy import integrate
 from scipy.special import logsumexp
+from scipy.interpolate import interp1d
 from matplotlib import pyplot as plt
 from .set_parameters import *
 from .calc_cddf import HubbleByH0, path_length_int
@@ -1382,8 +1383,12 @@ class QSOLoaderZ(QSOLoader):
         plot the z_samples versus sample posteriors
         '''
         # loading from files to save memory
-        this_sample_log_posteriors_no_dla = self.sample_log_posteriors_no_dla[:, nspec]
-        this_sample_log_posteriors_dla    = self.sample_log_posteriors_dla[:, nspec]
+        nspec_nan = np.where(~self.nan_inds)[0][nspec]
+        this_sample_log_posteriors_no_dla = self.sample_log_posteriors_no_dla[:, nspec_nan]
+        this_sample_log_posteriors_dla    = self.sample_log_posteriors_dla[:, nspec_nan]
+
+        this_sample_log_posteriors = logsumexp([
+            this_sample_log_posteriors_no_dla, this_sample_log_posteriors_dla], axis=0)
 
         make_fig()
 
@@ -1394,8 +1399,8 @@ class QSOLoaderZ(QSOLoader):
         
         if dla_samples:
             plt.scatter(self.offset_samples_qso,
-                this_sample_log_posteriors_dla,
-                color="C1", label="P(DLA | D)", alpha=0.5,
+                this_sample_log_posteriors,
+                color="red", label="P(DLA + ¬DLA | D)", alpha=0.5,
                 rasterized=True)
 
         # plot verticle lines corresponding to metal lines miss fitted lya
@@ -1473,11 +1478,41 @@ class QSOLoaderZ(QSOLoader):
 
         # count the effective optical depth from members in Lyman series
         scale_factor = self.total_scale_factor(
-            self.GP.tau_0_kim, self.GP.beta_kim, self.z_qsos[nspec], 
+            self.GP.tau_0_kim, self.GP.beta_kim, z_qso, 
             self.GP.rest_wavelengths, num_lines=num_forest_lines)
-        
+
+        # construct the uncertainty, diag(K) + Omega + V
+        # build covariance matrix
+        v_interpolator = interp1d(this_rest_wavelengths, this_noise_variance)
+
+        # only take noise in between observed lambda
+        ind =  (this_rest_wavelengths.min() <= rest_wavelengths) & (
+                this_rest_wavelengths.max() >= rest_wavelengths)
+
+        this_v = v_interpolator(rest_wavelengths[ind])
+
+        this_omega2 = np.exp( 2 * self.GP.log_omega )
+
+        # scaling factor in the omega2
+        noise_scale_factor = self.total_scale_factor(
+            np.exp(self.GP.log_tau_0), np.exp(self.GP.log_beta), z_qso,
+            self.GP.rest_wavelengths, num_lines=num_forest_lines)
+        noise_scale_factor = 1 - noise_scale_factor + np.exp(self.GP.log_c_0)
+
+        this_omega2 = this_omega2 * noise_scale_factor**2
+
+        # now we also consider the suppression in the noise
+        this_M = self.GP.M
         if suppressed:
-            this_mu = this_mu * scale_factor
+            this_mu     = this_mu     * scale_factor
+            this_M      = this_M      * scale_factor[:, None]
+            this_omega2 = this_omega2 * scale_factor**2.
+
+        # you get only diag since there's no clear way to plot covariance in the plot
+        K      = np.matmul(this_M , this_M.T )
+        this_k = np.diag(K)
+
+        this_error = this_omega2[ind] + this_k[ind] + this_v
 
         # plt.figure(figsize=(16, 5))
         if new_fig:
@@ -1487,6 +1522,9 @@ class QSOLoaderZ(QSOLoader):
         plt.plot(rest_wavelengths, this_mu, 
             label=label + r"$\mathcal{M}$"+r" DLA({n})".format(n=0) + ": {:.3g}".format(self.p_no_dlas[nspec]), 
             color=color)
+
+        plt.fill_between(rest_wavelengths[ind],
+            this_mu[ind] - 2*this_error, this_mu[ind] + 2*this_error, alpha=0.8, color="orange")
 
         plt.xlabel(r"rest-wavelengths $\lambda_{\mathrm{rest}}$ $\AA$")
         plt.ylabel(r"normalised flux")

--- a/test_qsosz.py
+++ b/test_qsosz.py
@@ -24,7 +24,7 @@ plt.show()
 nspec = 15
 
 # this plots P(M|D) versus z_samples
-qsos.plot_z_sample_posteriors(nspec, dla_samples=False)
+qsos.plot_z_sample_posteriors(nspec, dla_samples=True)
 plt.show()
 
 # Plot the spectra with this_mu, using MAP z estimate
@@ -43,13 +43,13 @@ for nspec in np.where(index)[0]:
     print("Plotting {}/{} ...".format(nspec, len(qsos.z_qsos)))
 
     # saving plots: z_samples versus poseteriors
-    qsos.plot_z_sample_posteriors(nspec, dla_samples=False)
+    qsos.plot_z_sample_posteriors(nspec, dla_samples=True)
     plt.savefig("{}_posterior_zqso_samples_delta_z_{}.pdf".format(
             qsos.thing_ids[nspec], delta_z),
             dpi=150, format='pdf')
-    # plt.close()
-    # plt.clf()
-    plt.show()
+    plt.close()
+    plt.clf()
+    # plt.show()
 
     # saving plots: MAP estimate model
     qsos.plot_this_mu(nspec=nspec, suppressed=True, 
@@ -58,9 +58,9 @@ for nspec in np.where(index)[0]:
     make_zqso_plots.save_figure(
         "{}_this_mu_delta_z_{}_ZMAP".format(
             qsos.thing_ids[nspec], delta_z))
-    # plt.close()
-    # plt.clf()
-    plt.show()
+    plt.close()
+    plt.clf()
+    # plt.show()
 
     # saving plots: True QSO rest-frame
     qsos.plot_this_mu(nspec=nspec, suppressed=True, 
@@ -69,9 +69,9 @@ for nspec in np.where(index)[0]:
     make_zqso_plots.save_figure(
         "{}_this_mu_delta_z_{}_ZTrue".format(
             qsos.thing_ids[nspec], delta_z))
-    # plt.close()
-    # plt.clf()
-    plt.show()
+    plt.close()
+    plt.clf()
+    # plt.show()
 
 # inspect the this_wavelength due to the normalisation is weird
 this_wavelengths    = qsos.find_this_wavelengths(nspec)

--- a/test_qsosz.py
+++ b/test_qsosz.py
@@ -30,11 +30,13 @@ plt.show()
 # Plot the spectra with this_mu, using MAP z estimate
 qsos.plot_this_mu(nspec=nspec, suppressed=True, 
     num_voigt_lines=3, num_forest_lines=6, z_sample=qsos.z_map[nspec])
+plt.ylim(-1, 5)
 plt.show()
 
 # Plot the spectra with this_mu, using True zQSO
 qsos.plot_this_mu(nspec=nspec, suppressed=True, 
     num_voigt_lines=3, num_forest_lines=6, z_sample=qsos.z_qsos[nspec])
+plt.ylim(-1, 5)
 plt.show()
 
 for nspec in np.where(index)[0]:
@@ -45,29 +47,31 @@ for nspec in np.where(index)[0]:
     plt.savefig("{}_posterior_zqso_samples_delta_z_{}.pdf".format(
             qsos.thing_ids[nspec], delta_z),
             dpi=150, format='pdf')
-    plt.close()
-    plt.clf()
-    # plt.show()
+    # plt.close()
+    # plt.clf()
+    plt.show()
 
     # saving plots: MAP estimate model
     qsos.plot_this_mu(nspec=nspec, suppressed=True, 
         num_voigt_lines=3, num_forest_lines=6, z_sample=qsos.z_map[nspec])
+    plt.ylim(-1, 5)        
     make_zqso_plots.save_figure(
         "{}_this_mu_delta_z_{}_ZMAP".format(
             qsos.thing_ids[nspec], delta_z))
-    plt.close()
-    plt.clf()
-    # plt.show()
+    # plt.close()
+    # plt.clf()
+    plt.show()
 
     # saving plots: True QSO rest-frame
     qsos.plot_this_mu(nspec=nspec, suppressed=True, 
         num_voigt_lines=3, num_forest_lines=6, z_sample=qsos.z_qsos[nspec])
+    plt.ylim(-1, 5)    
     make_zqso_plots.save_figure(
         "{}_this_mu_delta_z_{}_ZTrue".format(
             qsos.thing_ids[nspec], delta_z))
-    plt.close()
-    plt.clf()
-    # plt.show()
+    # plt.close()
+    # plt.clf()
+    plt.show()
 
 # inspect the this_wavelength due to the normalisation is weird
 this_wavelengths    = qsos.find_this_wavelengths(nspec)


### PR DESCRIPTION
- Add uncertainty in this_mu: only accounts the diag term of the model
- Found a bug in the indexing in the sample posterior plotting function